### PR TITLE
Set pixel value to 0 if background > phase image

### DIFF
--- a/flifile/__init__.py
+++ b/flifile/__init__.py
@@ -141,7 +141,9 @@ class FliFile:
         data = data.reshape(self._di['IMSize'][::-1])
         if subtractbackground:
             self._bg = self.getbackground(squeeze=False)
+            mask = np.where(data < self._bg)
             data = data - self._bg
+            data[mask] = 0
         if squeeze:
             data = np.squeeze(data.transpose((5, 4, 2, 1, 3, 0, 6)))  # x,y,ph,t,z,fr,c
 


### PR DESCRIPTION
When a pixel value in the background image exceeds the pixel value in a phase image, then background correction can lead to unexpectedly high values in the corrected image. This PR compares the background image and the phase images and sets the pixel value to 0 for pixels where the background value exceeds the value in the phase image.